### PR TITLE
78 tutorial improvements

### DIFF
--- a/docs/deployment.adoc
+++ b/docs/deployment.adoc
@@ -12,7 +12,7 @@ Enonic Cloud is Enonic's fully managed and hassle free hosting option. Sit back,
 Enough with the sales pitch. Follow the steps below to get deploy your app on Enonic Cloud:
 
 === Task: Install application
-. Sign up by visiting https://cloud.enonic.com (no credit card needed)
+. Sign up by visiting https://cloud.enonic.com[https://cloud.enonic.com^] (no credit card needed)
 . After accessing your account for the first time, make sure to choose the `free trial` plan
 +
 .Enonic Cloud plans
@@ -110,7 +110,7 @@ Enonic XP is compatibile with just about any public cloud out there. There's a n
 
 Setting up the entire platform is beyond the scope of this tutorial. As such, we'll focus on the steps required for getting your app live - assuming you already have the platform running. 
 
-For more details on deplying the platform, check out https://developer.enonic.com/docs/xp/stable/deployment[the Deployment section of the XP reference docs].
+For more details on deplying the platform, check out https://developer.enonic.com/docs/xp/stable/deployment[the Deployment section of the XP reference docs^].
 
 === Installing the app
 
@@ -129,9 +129,9 @@ image::deployment-app-upload.png["The application installation menu with a blue 
 
 Second alternative is via API:
 
-If you have access to your server's management API (available on port 4848), you can also deploy directly via this endpoint, or by using https://developer.enonic.com/docs/enonic-cli/stable/xp#app[the CLI].
+If you have access to your server's management API (available on port 4848), you can also deploy directly via this endpoint, or by using https://developer.enonic.com/docs/enonic-cli/stable/xp#app[the CLI^].
 
-This approach is most commonly used in a https://developer.enonic.com/guides/ci-cd-for-xp-apps[Continuous Integration/Delivery] setup, where your build server automatically checks out, builds and installs the application.
+This approach is most commonly used in a https://developer.enonic.com/guides/ci-cd-for-xp-apps[Continuous Integration/Delivery^] setup, where your build server automatically checks out, builds and installs the application.
 
 [#vhosts]
 === Virtual hosts = pretty URLs
@@ -194,7 +194,7 @@ mapping.localhost.idProvider.system = default
 +
 This means that XP has updated the mappings and is ready to go.
 
-. To test this out, update your local hosts file (https://en.wikipedia.org/wiki/Hosts_%28file%29[_hosts file_ on Wikipedia]) to point `{vhost-host}` to `127.0.0.1` by adding the following line to the file:
+. To test this out, update your local hosts file (https://en.wikipedia.org/wiki/Hosts_%28file%29[_hosts file_ on Wikipedia^]) to point `{vhost-host}` to `127.0.0.1` by adding the following line to the file:
 +
 [source,conf,{subs}]
 ----
@@ -203,11 +203,11 @@ This means that XP has updated the mappings and is ready to go.
 +
 TIP: On Linux and macOS you'll find the hosts file at `/etc/hosts`. On Windows, it's located at  `c:\Windows\System32\Drivers\etc\hosts`
 
-. Now access `http://{vhost-host}:8080` in your browser. If all has gone well, you should see the familiar XP login screen.
+. Now access `http://{vhost-host}:8080[http://{vhost-host}:8080^]` in your browser. If all has gone well, you should see the familiar XP login screen.
 
 === Vhost troubleshooting
 
-If you're not seeing anything when you direct your browser to `http://{vhost-host}:8080` or aren't able to access the resources, that may be due to a browser setting. Try using a different browser and see if that makes a difference. Alternatively, you can try running
+If you're not seeing anything when you direct your browser to `http://{vhost-host}:8080[http://{vhost-host}:8080^]` or aren't able to access the resources, that may be due to a browser setting. Try using a different browser and see if that makes a difference. Alternatively, you can try running
 
 [source,bash,{subs}]
 ----

--- a/docs/rich-text.adoc
+++ b/docs/rich-text.adoc
@@ -7,9 +7,9 @@ If you want to work with rich text, HtmlArea is the input type to go.
 
 This input type offers some very powerful editing capabilities and a lot of configuration options. 
 
-This whole {document} is dedicated to the https://developer.enonic.com/docs/xp/stable/cms/schemas/input-types/htmlarea[HtmlArea input type] and the editor used to define its data. 
+This whole {document} is dedicated to the https://developer.enonic.com/docs/xp/stable/cms/schemas/input-types/htmlarea[HtmlArea input type^] and the editor used to define its data. 
 
-The user-oriented documentation of the Rich text editor can be found in the https://developer.enonic.com/docs/content-studio/stable/editor/rich-text-editor[Content Studio docs].
+The user-oriented documentation of the Rich text editor can be found in the https://developer.enonic.com/docs/content-studio/stable/editor/rich-text-editor[Content Studio docs^].
 
 NOTE: {see-prev-docs}
 
@@ -72,7 +72,7 @@ Finally, if you want to exclude most tools, but not all, you can exclude all and
 .An HtmlArea with a selection of tools and `<exclude>*</exclude>`
 image::input-type-html-area-some-controls.png[An HtmlArea configured to include a selection of editing tools, {image-s}, align=center]
 
-As introduced in the beginning, for a full overview of the available text tools and HtmlArea configuration options, visit the https://developer.enonic.com/docs/xp/stable/cms/schemas/input-types/htmlarea[HtmlArea input type reference docs].
+As introduced in the beginning, for a full overview of the available text tools and HtmlArea configuration options, visit the https://developer.enonic.com/docs/xp/stable/cms/schemas/input-types/htmlarea[HtmlArea input type reference docs^].
 
 === Task: {content-type-2-capitalized} description
 
@@ -148,7 +148,7 @@ The following options are available: Caption, alt text, change the image's justi
 
 Try out the image controls that Content Studio give you by uploading a picture and seeing what you can do with it. 
 
-We looked at xref:input-types#_working_with_images[editing images in the previous {document}], but when inserting images in the HtmlArea, you also have something called "image styles", which we'll have a look at now.
+We looked at xref:input-types#_working_with_images[editing images in the input types {document}], but when inserting images in the HtmlArea, you also have something called "image styles", which we'll have a look at now.
 
 Continue editing the "Lynx" content created in the previous task.
 
@@ -159,7 +159,7 @@ image::rich-text-toolbar-image-highlight.png[The rich text toolbar with the imag
 +
 . You'll be greeted by the "insert image" dialog:
 +
-.The HtmlArea insert image dialog. Photo by https://unsplash.com/@zmachacek[Zdeněk Macháček]
+.The HtmlArea insert image dialog. Photo by https://unsplash.com/@zmachacek[Zdeněk Macháček^]
 image::rich-text-insert-image.png["The insert image dialog, showing the image, an image styles dropdown, caption, and alt text fields", {image-l}]
 +
 . When accessing the "image styles" dropdown, you'll find that it's only got two options and neither of them seem to do much. To make this more exciting, let's also create a custom image style.
@@ -181,7 +181,7 @@ In your app, add a new file:
 <1> The aspect ratio controls how the image is displayed. 1:1 makes the image square.
 <2> The filters add a grayscale effect and then a border
 +
-NOTE: https://developer.enonic.com/docs/xp/stable/cms/styles[The styles reference doc] has more information on how you can style your images, so go check it out for a deeper dive.
+NOTE: https://developer.enonic.com/docs/xp/stable/cms/styles[The styles reference doc^] has more information on how you can style your images, so go check it out for a deeper dive.
 +
 . With this style picked up by XP, you'll have the "Grayscale" option available in the image styles dropdown. Select it to apply it to the image and update your image.
 +
@@ -198,7 +198,7 @@ Similar to content types, macros can define forms that help editors configure th
 
 === Task: Embed iframe macro
 
-The embed macro enable you to insert iframes. In this context, we'll embed this https://www.youtube.com/watch?v=gr5EwZo_CHQ[Lynx youtube video].
+The embed macro enable you to insert iframes. In this context, we'll embed this https://www.youtube.com/watch?v=gr5EwZo_CHQ[Lynx youtube video^].
 
 Let's add the macro to the "Lynx" content item.
 
@@ -213,7 +213,7 @@ NOTE: This macro can't be previewed because the Embed iframe macro does not incl
 
 As you'll see in next section, when querying the description of an Animal content, you'll be able to properly get the iframe we passed to "Embed iframe" macro and process it as you'd like in your front-end.
 
-TIP: For more information on macros, including how to create your very own, visit to https://developer.enonic.com/docs/xp/stable/cms/macros[the macro reference docs].
+TIP: For more information on macros, including how to create your very own, visit to https://developer.enonic.com/docs/xp/stable/cms/macros[the macro reference docs^].
 
 == GraphQL API
 
@@ -370,7 +370,7 @@ In the processed HTML, you can see the `<img>` element with style attributes. Ad
 
 But wait, there's more! 
 
-If you want to optimize how fast images load on various devices, Guillotine can also return the image in multiple different sizes (using https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset[the `srcset` attribute (MDN)]). This is achieved by adding an argument to the `description` field:
+If you want to optimize how fast images load on various devices, Guillotine can also return the image in multiple different sizes (using https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset[the `srcset` attribute (MDN)^]). This is achieved by adding an argument to the `description` field:
 
 .Fetching rich text with `srcset`
 [source,GraphQL,]

--- a/docs/sets.adoc
+++ b/docs/sets.adoc
@@ -40,7 +40,7 @@ image::field-set.png["A field set containing TextLine and TextArea inputs. The f
 
 Item sets also allow you to group input fields, but as opposed to field sets, item sets group values _both_ visually _and_ on a structural level. Item sets can be arbitrarily nested.
 
-- The https://developer.enonic.com/docs/xp/stable/cms/schemas/item-set[item set documentation] does a standout job of explaining exactly how they work, so check that out for an overview.
+- The https://developer.enonic.com/docs/xp/stable/cms/schemas/item-set[item set documentation^] does a standout job of explaining exactly how they work, so check that out for an overview.
 
 .An item set containing contact info
 image::item-set-sample.png["A pair of visually grouped inputs on a card element. The card has a header that says 'contact info'. There is also a button to add more contact info forms.", {image-s}, align=center]
@@ -51,7 +51,7 @@ Option sets enable editors (working in Content Studio) to choose from a set of p
 
 Option sets where users can select only one of a number of options are known as _single-select_ option sets. You can also use a _multi-select_ option set if the user should be able to select multiple options simultaneously. We'll look at this too in a task.
 
-- The https://developer.enonic.com/docs/xp/stable/cms/schemas/option-set[option set reference documentation] provides a good overview (with accompanying pictures) of how option sets work.
+- The https://developer.enonic.com/docs/xp/stable/cms/schemas/option-set[option set reference documentation^] provides a good overview (with accompanying pictures) of how option sets work.
 
 .A multi-select option set
 image::option-set-sample.png["An input form labelled 'multi-selection'. The user has selected one out of four options. Some options contain extra data such as an image selector or other input fields.", {image-s}, align=center]

--- a/docs/x-data.adoc
+++ b/docs/x-data.adoc
@@ -55,7 +55,7 @@ image::notes-x-data.png["Notes x-data fields showing in the bottom of an animal 
 +
 . Finally, add some notes to some content.
 
-NOTE: For more details and configuration options for X-data, visit https://developer.enonic.com/docs/xp/stable/cms/x-data[the X-data documentation].
+NOTE: For more details and configuration options for X-data, visit https://developer.enonic.com/docs/xp/stable/cms/x-data[the X-data documentation^].
 
 == Headless
 
@@ -186,7 +186,7 @@ There's a known app on Enonic market named _SEO Metafields app_. Its main purpos
 
 This is a bonus section, so you're not missing much to skip it, but it's worth installing it to better understand capabilities of X-data.
 
-. Install the https://market.enonic.com/vendors/enonic/seo-metafields[SEO Metafields app].
+. Install the https://market.enonic.com/vendors/enonic/seo-metafields[SEO Metafields app^].
 +
 image::x-data-seo-app-install.png["Install SEO Metafields app",{image-l}]
 +


### PR DESCRIPTION
Add carat to links that are too open in new tab, specify chapter instead of "previous chapter" when it is not previous chapter.